### PR TITLE
Use generator syntax to support decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ class MySortableComponent extends React.Component {
     }
 }
 
-export default SortableMixin(MySortableComponent, sortableOptions);
+export default SortableMixin(sortableOptions)(MySortableComponent);
 ```
 
 ## Examples
@@ -158,7 +158,7 @@ class Sortable1 extends React.Component {
     }
 }
 
-export default SortableMixin(Sortable1, { group: 'shared' });
+export default SortableMixin({ group: 'shared' })(Sortable1);
 ```
 
 File: sortable2.jsx
@@ -185,5 +185,5 @@ class Sortable2 extends React.Component {
     }
 }
 
-export default SortableMixin(Sortable2, { group: 'shared' });
+export default SortableMixin({ group: 'shared' })(Sortable2);
 ```

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -40,7 +40,7 @@ const extend = (target, ...sources) => {
     return target;
 };
 
-const SortableMixin = (Component, sortableOptions = defaultOptions) => class extends React.Component {
+const SortableMixin = (sortableOptions = defaultOptions) => (Component) => class extends React.Component {
     sortableInstance = null;
     sortableOptions = sortableOptions;
 


### PR DESCRIPTION
This allows us to use a decorator when connecting the component, as is typically standard in higher order components for ES6.  http://asaf.github.io/blog/2015/06/23/extending-behavior-of-react-components-by-es6-decorators/

We're now able to do this:

``` js
import Sortable from 'react-sortablejs'

@connect(
    (state) => ({
        ...state.myItems
    })
)
@Sortable({
    ref: 'list',
    model: 'myItems'
})
export default class RestaurantInventoryItems extends React.Component {

...
}
```
