### PR TITLE
Pass event down to onChange

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -69,10 +69,10 @@ module.exports = class extends React.Component {
                             evt.item.parentNode.removeChild(evt.item);
                         }
 
-                        remote.props.onChange && remote.props.onChange(remoteItems, remote.sortable);
+                        remote.props.onChange && remote.props.onChange(remoteItems, remote.sortable, evt);
                     }
 
-                    this.props.onChange && this.props.onChange(items, this.sortable);
+                    this.props.onChange && this.props.onChange(items, this.sortable, evt);
                 }
 
                 setTimeout(() => {


### PR DESCRIPTION
~~Main reason I want to do this is to render a set of custom html elements rather than simple strings. Passing evt up lets me avoid a bunch of string parsing and instead just process the html element~~ (just found out about data-id :)

Useful for desynchronized groups where you can add items to one group but cannot add items to the other; adding to the other removes from the second list 

/cc @cheton 
