### PR TITLE
Make in use of onMoveFn's return value

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -59,9 +59,15 @@ module.exports = class extends React.Component {
                     this.props.onChange && this.props.onChange(items, this.sortable, evt);
                 }
 
-                setTimeout(() => {
-                    eventHandler && eventHandler(evt);
-                }, 0);
+                switch (evt.type) {
+                    case 'move':
+                        if (eventHandler) return eventHandler(evt);
+                    default: 
+                        setTimeout(() => {
+                            eventHandler && eventHandler(evt);
+                        }, 0);
+                }
+                
             }
         });
 


### PR DESCRIPTION
In original library, returned value from onMove handler will be checked to determine to skip moving action on a element.

Ref: https://github.com/RubaXa/Sortable#options
