### PR TITLE
make it possible to use react component or string

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ const SortableList = ({ items, onChange }) => {
                     }
                 }}
 
-                // [Optional] A tag to specify the wrapping element. Defaults to "div".
+                // [Optional] A tag or react component to specify the wrapping element. Defaults to "div".
+                // In a case of a react component it is required to has children in the component
+                // and pass it down.
                 tag="ul"
 
                 // [Optional] The onChange method allows you to implement a controlled component and keep

--- a/src/Sortable.jsx
+++ b/src/Sortable.jsx
@@ -13,7 +13,10 @@ class Sortable extends Component {
     static propTypes = {
         options: PropTypes.object,
         onChange: PropTypes.func,
-        tag: PropTypes.string,
+        tag: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.func
+        ]),
         style: PropTypes.object
     };
     static defaultProps = {


### PR DESCRIPTION
There is PropTypes warning in a case when I use react class instead of string, although it works fine with function.