### PR TITLE
Replaced ReacDOM.findDOMNode by using ref

### DIFF
--- a/src/Sortable.jsx
+++ b/src/Sortable.jsx
@@ -82,7 +82,7 @@ class Sortable extends Component {
             };
         });
 
-        this.sortable = SortableJS.create(ReactDOM.findDOMNode(this), options);
+        this.sortable = SortableJS.create(this.node, options);
     }
     componentWillUnmount() {
         if (this.sortable) {
@@ -97,7 +97,7 @@ class Sortable extends Component {
         delete props.onChange;
 
         return (
-            <Component {...props} />
+            <Component {...props} ref={(node) => { return this.node = node; }} />
         );
     }
 }


### PR DESCRIPTION
I opened this PR because I found myself with an issue when working with React & React DOM versions 16.2.0. 
The error message was 
_Uncaught Sortable: `el` must be HTMLElement, and not [object null]_
and I fixed it by replacing the use of ReacDOM.findDOMNode with a ref attribute associated to the wrapping component rendered which seems to be the more appropriate way to reference an underlying DOM element with newer React versions (https://reactjs.org/docs/react-dom.html#finddomnode)