### PR TITLE
Fix failed to execute 'removeChild' on 'Node', #55

### DIFF
--- a/src/Sortable.jsx
+++ b/src/Sortable.jsx
@@ -86,6 +86,15 @@ class Sortable extends Component {
         this.sortable = SortableJS.create(this.node, options);
     }
 
+    shouldComponentUpdate(nextProps) {
+        // If onChange is null, it is an UnControlled component
+        // Don't let React re-render it by setting return to false
+        if (!nextProps.onChange) {
+            return false;
+        }
+        return true;
+    }
+
     componentWillUnmount() {
         if (this.sortable) {
             this.sortable.destroy();


### PR DESCRIPTION
This fix aims at [Issue 55](https://github.com/SortableJS/react-sortablejs/issues/55)

Problem:
The `uncontrolled component` is going to `manipulate the DOM`, and `incorrect react-fiber tree` was made when it does `virtual dom diff`. Finally, when react-dom try to react to manipulate the DOM, it will fail.

Solution:
Use `shouldComponentUpdate` lifecycle to prevent uncontrolled component to re-render.