### PR TITLE
Add support for custom components as tag

### DIFF
--- a/src/Sortable.jsx
+++ b/src/Sortable.jsx
@@ -1,6 +1,7 @@
 /* eslint consistent-return: 0 */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { findDOMNode } from 'react-dom';
 import SortableJS from 'sortablejs';
 
 const store = {
@@ -83,7 +84,7 @@ class Sortable extends Component {
             };
         });
 
-        this.sortable = SortableJS.create(this.node, options);
+        this.sortable = SortableJS.create(findDOMNode(this.node), options);
     }
 
     shouldComponentUpdate(nextProps) {


### PR DESCRIPTION
Use `findDOMNode` from `react-dom` package to find the dom ref.