### PR TITLE
removed AutoScroll and OnSpill exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "waynevspersonal@gmail.com"
   },
   "license": "MIT",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,6 @@ export { ReactSortable } from "./react-sortable";
 export * from "./types";
 export {
   MultiDrag,
-  OnSpill,
-  AutoScroll,
   Swap,
   DOMRect,
   Direction,


### PR DESCRIPTION
As I understood, according to [#1672](https://github.com/SortableJS/Sortable/issues/1672) issue, AutoScroll and OnSpill plugins now included into the sortablejs library, so they don't need explicit export (I'm actually not completely sure about it).

So, being one of the guys who experienced [#97 issue](https://github.com/SortableJS/react-sortablejs/issues/97), I tried to remove exports and error was gone. Hope it may help.


Related issues:
[#1672](https://github.com/SortableJS/Sortable/issues/1672)
[#97](https://github.com/SortableJS/react-sortablejs/issues/97)
