### PR TITLE
Added extra checking for existence of oldIndicies

### DIFF
--- a/dist/index.es.js
+++ b/dist/index.es.js
@@ -151,7 +151,7 @@ function handleStateAdd(normalized, list) {
     return newList;
 }
 function getMode(evt) {
-    if (evt.oldIndicies.length > 0)
+    if (evt.oldIndicies && evt.oldIndicies.length > 0)
         return "multidrag";
     if (evt.swapItem)
         return "swap";

--- a/dist/index.js
+++ b/dist/index.js
@@ -157,7 +157,7 @@ function handleStateAdd(normalized, list) {
     return newList;
 }
 function getMode(evt) {
-    if (evt.oldIndicies.length > 0)
+    if (evt.oldIndicies && evt.oldIndicies.length > 0)
         return "multidrag";
     if (evt.swapItem)
         return "swap";

--- a/src/util.ts
+++ b/src/util.ts
@@ -124,7 +124,7 @@ export function handleStateAdd<T extends ItemInterface>(
 }
 
 export function getMode(evt: MultiDragEvent) {
-  if (evt.oldIndicies.length > 0) return "multidrag";
+  if (evt.oldIndicies && evt.oldIndicies.length > 0) return "multidrag";
   if (evt.swapItem) return "swap";
   return "normal";
 }


### PR DESCRIPTION
Versions after 2.0.2 was throwing ```Cannot read property 'length' of undefined``` for a check of length of ```evt.oldIndicies```, right after the first drag&drop operation, so future interactions were impossible, that simple additional check helped me with that. Most likely I've introduced a dirty hack though :D 

found #111 issue, and as stated there, instantiating MultiDrag and connecting it manually with Sortable via

```Sortable.mount(new MultiDrag());```

helps, but it seems more like a workaround and not an expected behaviour. 


By the way, I can confirm that react-sortablejs works with AntDesign and its form elements.