### PR TITLE
Specify sortablejs as a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,6 @@ npm install --save react-sortablejs
 yarn add react-sortablejs
 ```
 
-Please note that `sortablejs` is not required, as it's bundled in this component.
-
 ## Learn
 
 Here is the TLDR of what sortable is:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "waynevanson@gmail.com"
   },
   "license": "MIT",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",
@@ -25,13 +25,13 @@
     "toc": "doctoc ."
   },
   "peerDependencies": {
+    "sortablejs": "^1.10.1",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"
   },
   "dependencies": {
     "@types/sortablejs": "^1.10.0",
     "classnames": "^2.2.6",
-    "sortablejs": "1.10.1",
     "tiny-invariant": "^1.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
There are potentially situations where users may need certain modifications made to sortablejs that are not part of its release candidate. I'm setting sortablejs as a peer dependency in order to allow me to set forked versions of sortablejs while continuing to leverage the awesome work you've done here with react-sortablejs. 

Let me know if there is anything else you need to make this happen. 