### PR TITLE
Upgrade sortablejs, fixes transform of dragged elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@types/sortablejs": "^1.10.0",
     "classnames": "^2.2.6",
-    "sortablejs": "1.10.1",
+    "sortablejs": "1.10.2",
     "tiny-invariant": "^1.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
There's [the original issue](https://github.com/SortableJS/Sortable/issues/1644) which I met as well.
My case is super similar:

It doesn't clean up `transform` on the drag end:
![](http://g.recordit.co/00JpkSFbo2.gif)
and all elements with absolute positioning that are relative to sortable items sink under like below:
![image](https://user-images.githubusercontent.com/11492412/91311035-432acb00-e7bb-11ea-8029-361d37f71c3a.png)