### PR TITLE
Fix issue when one of a children is undefined

### DIFF
--- a/src/react-sortable.tsx
+++ b/src/react-sortable.tsx
@@ -110,7 +110,9 @@ Please read the updated README.md at https://github.com/SortableJS/react-sortabl
     const dataid = dataIdAttr || "data-id";
     /* eslint-disable-next-line */
     return Children.map(children as ReactElement<any>[], (child, index) => {
-      const item = list[index];
+      if (!child) return undefined
+      
+      const item = list[index] || {};
       const { className: prevClassName } = child.props;
 
       // @todo - handle the function if avalable. I don't think anyone will be doing this soon.

--- a/src/react-sortable.tsx
+++ b/src/react-sortable.tsx
@@ -110,7 +110,7 @@ Please read the updated README.md at https://github.com/SortableJS/react-sortabl
     const dataid = dataIdAttr || "data-id";
     /* eslint-disable-next-line */
     return Children.map(children as ReactElement<any>[], (child, index) => {
-      if (child===undefined) return undefined
+      if (child === undefined) return undefined
       
       const item = list[index] || {};
       const { className: prevClassName } = child.props;

--- a/src/react-sortable.tsx
+++ b/src/react-sortable.tsx
@@ -110,7 +110,7 @@ Please read the updated README.md at https://github.com/SortableJS/react-sortabl
     const dataid = dataIdAttr || "data-id";
     /* eslint-disable-next-line */
     return Children.map(children as ReactElement<any>[], (child, index) => {
-      if (!child) return undefined
+      if (child===undefined) return undefined
       
       const item = list[index] || {};
       const { className: prevClassName } = child.props;


### PR DESCRIPTION
Firstly huge thanks for such amazing module!
In some edge cases (like in my own) there can be a `undefined` React child. Easy to reproduce:
```js
<ReactSortable>
  {some_var ? <li>123</li> : undefined}
  <li>123</li>
</ReactSortable>
```

In such case crash happen because code can't read property of undefined object.
Just check changes that I made into `react-sortable.tsx` file you will understand what I'm trying to achieve.

I also changed this line from `const item = list[index];` to `const item = list[index] || {};` , just to be sure that if list doesn't have particular index, whole code not fail.
This two changes are made to prevent edge case crashes. In my own app I spend a lot of time to find out why sometime app is crashing.

Please, please approve this pull request!