### PR TITLE
fix(react18): add `children` to `ReactSortableProps`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,6 @@ export {
   SortableEvent,
   SortableOptions,
   Utils,
-} from "sortablejs"
-export { ReactSortable } from "./react-sortable"
-export * from "./types"
+} from "sortablejs";
+export { ReactSortable } from "./react-sortable";
+export * from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import {
   CSSProperties,
   ForwardRefExoticComponent,
   ReactHTML,
+  ReactNode,
   RefAttributes,
 } from "react";
 import Sortable, { MoveEvent, Options, SortableEvent } from "sortablejs";
@@ -57,6 +58,7 @@ export interface ReactSortableProps<T>
   style?: CSSProperties;
   className?: string;
   id?: string;
+  children?: ReactNode;
 }
 
 /**


### PR DESCRIPTION
This adds the explicit `children` prop to `ReactSortableProps`. 

closes #233 